### PR TITLE
Include an entrypoint.sh to support any username

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,9 +90,11 @@ VOLUME /var/lib/hive
 
 USER 1002
 
+COPY entrypoint.sh /
+ENTRYPOINT /entrypoint.sh
+
 LABEL io.k8s.display-name="OpenShift Hive" \
       io.k8s.description="This is an image used by Cost Management to install and run Hive." \
       summary="This is an image used by Cost Management to install and run Hive." \
       io.openshift.tags="openshift" \
       maintainer="<cost-mgmt@redhat.com>"
-

--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ Docker Image build of Hive from RHEL UBI base image. This includes mysql, postgr
 * `pr_check.sh` : PR check script (You should not need to modify this)
 * `build_deploy.sh` : Build and deploy to Red Hat cloudservices quay org. (You should not need to modify this script)
 
+# Usage
+
+It supports [arbitrary user ids](https://docs.openshift.com/container-platform/4.7/openshift_images/create-images.html#use-uid_create-images)
+by using the packaged `/entrypoint.sh` as container command to add UID and
+username. You can use arguments like `/opt/hive/bin/hive --service metastore` to
+start a Hive metastore. If you want to customize this feature, define a
+different command instead.
+
+**Notice**: the default username is `hadoop`, customize it by providing an
+environment variable named `USER_NAME`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# add UID to /etc/passwd if missing
+if ! whoami &> /dev/null; then
+    if test -w /etc/passwd || stat -c "%a" /etc/passwd | grep -qE '.[267].'; then
+        echo "Adding user ${USER_NAME:-hadoop} with current UID $(id -u) to /etc/passwd"
+        # Remove existing entry with user first.
+        # cannot use sed -i because we do not have permission to write new
+        # files into /etc
+        sed  "/${USER_NAME:-hadoop}:x/d" /etc/passwd > /tmp/passwd
+        # add our user with our current user ID into passwd
+        echo "${USER_NAME:-hadoop}:x:$(id -u):0:${USER_NAME:-hadoop} user:${HOME}:/sbin/nologin" >> /tmp/passwd
+        # overwrite existing contents with new contents (cannot replace the
+        # file due to permissions)
+        cat /tmp/passwd > /etc/passwd
+        rm /tmp/passwd
+    fi
+fi
+
+exec $@


### PR DESCRIPTION
Fixes #8 

The `entrypoint.sh` comes from https://github.com/opendatahub-io/odh-manifests/blob/fa39cec574c523ae37b67f8a67b0e8bc476ce2a8/trino/base/hive-metastore-entrypoint.yaml#L42-L57