### PR TITLE
some clowdapp tweaks

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: hive
@@ -469,7 +469,7 @@ objects:
           failureThreshold: 3
           tcpSocket:
             port: 8000
-          initialDelaySeconds: 180
+          initialDelaySeconds: 60
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
@@ -478,7 +478,7 @@ objects:
             path: /
             port: 9000
             scheme: HTTP
-          initialDelaySeconds: 180
+          initialDelaySeconds: 60
           periodSeconds: 10
           successThreshold: 1
           failureThreshold: 3
@@ -575,7 +575,7 @@ objects:
   kind: Secret # For ephemeral/local environment only
   metadata:
     name: hive-db
-  data:
+  stringData:
     database_name: "${HIVE_DB_NAME_EPH}"
     database_user: "${HIVE_DB_USER_EPH}"
     database_password: "${HIVE_DB_PASSWORD_EPH}"
@@ -628,8 +628,8 @@ parameters:
   value: 'hive-s3'
 
 - name: HIVE_DB_NAME_EPH
-  value: aGl2ZQ== # hive
+  value: hive
 - name: HIVE_DB_USER_EPH
-  value: aGl2ZQ== # hive
+  value: hive
 - name: HIVE_DB_PASSWORD_EPH
-  value: aGl2ZQ== # hive
+  value: hive


### PR DESCRIPTION
1. update the apiVersion because of:
```
Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource
```
2. decrease the delay for liveness/readiness probes. This pod spins up relatively quickly in the ephemeral environment, so 1 minute should be sufficient.
3. change the secret data field to stringData. This should make updating the secret a little more intuitive if someone ever needed to change this secret. No more b64 encoding.