### PR TITLE
fix clowdapp jmx-config.yaml name

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -323,7 +323,7 @@ objects:
       fi
 
       # Set JMX options
-      export JMX_OPTIONS="-javaagent:${METASTORE_HOME}/lib/jmx_exporter.jar=9000:${METASTORE_HOME}/conf/jmx-config.yml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10000 -Dcom.sun.management.jmxremote.rmi.port=10000 -Djava.rmi.server.hostname=127.0.0.1"
+      export JMX_OPTIONS="-javaagent:${METASTORE_HOME}/lib/jmx_exporter.jar=9000:${METASTORE_HOME}/conf/jmx-config.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10000 -Dcom.sun.management.jmxremote.rmi.port=10000 -Djava.rmi.server.hostname=127.0.0.1"
 
       # Set garbage collection logs
       export GC_SETTINGS="${GC_SETTINGS} -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:${HADOOP_HOME}/logs/gc.log"


### PR DESCRIPTION
Fixes:
```
Caused by: java.io.FileNotFoundException: /opt/hive-metastore-bin/conf/jmx-config.yml (No such file or directory)
```