### PR TITLE
Support for arbitrary user ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ Docker Image build of Hive from RHEL UBI base image. This includes mysql, postgr
 * `pr_check.sh` : PR check script (You should not need to modify this)
 * `build_deploy.sh` : Build and deploy to Red Hat cloudservices quay org. (You should not need to modify this script)
 
+# Usage
+
+This image supports [arbitrary user ids](https://docs.openshift.com/container-platform/4.7/openshift_images/create-images.html#use-uid_create-images)
+by using the packaged `/entrypoint.sh` as container command to add UID and
+username.
+
+**Notice**: the default username is `hadoop`, customize it by providing an
+environment variable named `USER_NAME`.

--- a/default/scripts/entrypoint.sh
+++ b/default/scripts/entrypoint.sh
@@ -6,6 +6,24 @@ export HADOOP_OPTS="${HADOOP_OPTS} ${VM_OPTIONS} ${GC_SETTINGS} ${JMX_OPTIONS}"
 export HIVE_OPTS="${HIVE_OPTS} --hiveconf metastore.root.logger=${HIVE_LOGLEVEL},console "
 export PATH=${METASTORE_HOME}/bin:${HADOOP_HOME}/bin:$PATH
 
+set -e
+# add UID to /etc/passwd if missing
+if ! whoami &> /dev/null; then
+    if test -w /etc/passwd || stat -c "%a" /etc/passwd | grep -qE '.[267].'; then
+        echo "Adding user ${USER_NAME:-hadoop} with current UID $(id -u) to /etc/passwd"
+        # Remove existing entry with user first.
+        # cannot use sed -i because we do not have permission to write new
+        # files into /etc
+        sed  "/${USER_NAME:-hadoop}:x/d" /etc/passwd > /tmp/passwd
+        # add our user with our current user ID into passwd
+        echo "${USER_NAME:-hadoop}:x:$(id -u):0:${USER_NAME:-hadoop} user:${HOME}:/sbin/nologin" >> /tmp/passwd
+        # overwrite existing contents with new contents (cannot replace the
+        # file due to permissions)
+        cat /tmp/passwd > /etc/passwd
+        rm /tmp/passwd
+    fi
+fi
+
 set +e
 if schematool -dbType postgres -info -verbose; then
     echo "Hive metastore schema verified."

--- a/image_build_num.txt
+++ b/image_build_num.txt
@@ -1,1 +1,1 @@
-metastore-008
+metastore-009


### PR DESCRIPTION
This PR adds support for arbitrary user ids by assigning a name to the id if it does not have one already. This is particularly relevant when running this image in Red Hat OpenShift: https://docs.openshift.com/container-platform/4.7/openshift_images/create-images.html#use-uid_create-images

This fix has been tested on a Red Hat OpenShift cluster running in Azure:
![Screen Shot 2022-07-28 at 11 12 33](https://user-images.githubusercontent.com/5122881/181599259-4eaea6f0-268f-483d-bd07-3de3f8e128fe.png)

Fixes: https://github.com/RedHatInsights/ubi-hive/issues/8

Co-authored-by: Shawn Zhu <shawn.zhu@lifeomic.com>