### PR TITLE
COST-3130: Add kube-linter annotations in ClowdApp metadata

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -387,6 +387,8 @@ objects:
   kind: ClowdApp
   metadata:
     name: hive
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses 1 pod as currently the metastore is a singleton
   spec:
     envName: ${ENV_NAME}
     deployments:


### PR DESCRIPTION
- Add kube-linter annotations in ClowdApp metadata
- These should be removed when https://issues.redhat.com/browse/RHCLOUD-23016 is resolved